### PR TITLE
Prevent empty partner orders

### DIFF
--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -171,6 +171,11 @@ def create_partner_order():
     }
     """
 
+    payload = request.json
+
+    if 'items' not in payload or len(payload.get('items')) == 0:
+        return 'Invalid request payload: The order payload does not contain any items.', 400
+
     order = Order()
     db.session.add(order)
     db.session.commit()

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -176,6 +176,10 @@ def create_partner_order():
     if 'items' not in payload or len(payload.get('items')) == 0:
         return 'Invalid request payload: The order payload does not contain any items.', 400
 
+    for item in payload.get('items'):
+        if item.get('quantity') < 1:
+            return 'Invalid request: Quantity must be a positive integer.', 400
+
     order = Order()
     db.session.add(order)
     db.session.commit()

--- a/backend/tests/api/order_test.py
+++ b/backend/tests/api/order_test.py
@@ -156,3 +156,13 @@ class OrderApiTest(HoagieTester):
             assert added_order.items[0].quantity == 2
             assert added_order.items[0].sandwich_id == 1
             assert added_order.status == Order.Status.SUBMITTED
+
+    def test_create_partner_order_without_items(self):
+        with app.test_client() as client:
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json')
+            assert result.status_code == 400
+
+    def test_create_partner_order_with_zero_items(self):
+        with app.test_client() as client:
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json')
+            assert result.status_code == 400

--- a/backend/tests/api/order_test.py
+++ b/backend/tests/api/order_test.py
@@ -162,7 +162,18 @@ class OrderApiTest(HoagieTester):
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json')
             assert result.status_code == 400
 
-    def test_create_partner_order_with_zero_items(self):
+    def test_create_partner_order_with_empty_items(self):
         with app.test_client() as client:
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json')
+            assert result.status_code == 400
+
+    def test_create_partner_order_with_quantity_zero(self):
+        with app.test_client() as client:
+            item_input = ApiOrderItemInput(
+                quantity=0,
+                sandwich_id=1
+            )
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
+                'items': [item_input.__dict__]
+            }), content_type='application/json')
             assert result.status_code == 400


### PR DESCRIPTION
These changes prevent the partner order API endpoint from creating empty orders.
Fixes #2.