### PR TITLE
Authentication

### DIFF
--- a/backend/alembic/versions/20260222052811_add_partner_session_table.py
+++ b/backend/alembic/versions/20260222052811_add_partner_session_table.py
@@ -1,0 +1,34 @@
+"""Add partner session table
+
+Revision ID: f1f5cb5972e4
+Revises: 36a2493288a8
+Create Date: 2026-02-22 05:28:11.519962
+
+"""
+# pylint: skip-file
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f1f5cb5972e4'
+down_revision = '36a2493288a8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS partner_session (
+                access_token CHAR(32) NOT NULL,
+                hoagie_partner_id INT UNSIGNED NOT NULL,
+                created_dttm TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                duration INT UNSIGNED NOT NULL DEFAULT 7200,
+               PRIMARY KEY(access_token)
+            )
+    """)
+
+
+def downgrade():
+    op.execute("""DROP TABLE partner_session""")

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -3,3 +3,4 @@ collected api route imports
 """
 from .sandwich import *
 from .order import *
+from .partner import *

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -171,6 +171,11 @@ def create_partner_order():
     }
     """
 
+    payload = request.json
+
+    if 'items' not in payload or len(payload.get('items')) == 0:
+        return 'Invalid request payload: The order payload does not contain any items.', 400
+
     order = Order()
     db.session.add(order)
     db.session.commit()

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -176,6 +176,10 @@ def create_partner_order():
     if 'items' not in payload or len(payload.get('items')) == 0:
         return 'Invalid request payload: The order payload does not contain any items.', 400
 
+    for item in payload.get('items'):
+        if item.get('quantity') < 1:
+            return 'Invalid request: Quantity must be a positive integer.', 400
+
     order = Order()
     db.session.add(order)
     db.session.commit()

--- a/backend/api/order.py
+++ b/backend/api/order.py
@@ -13,6 +13,7 @@ import phonenumbers
 from flask_common import app, db
 from models import Order
 from _helpers import safe_int
+from .partner import authenticate_partner_request
 
 
 @dataclass
@@ -170,6 +171,9 @@ def create_partner_order():
         phone_number?: str
     }
     """
+
+    if not authenticate_partner_request(request):
+        return 'Unauthorized request.', 401
 
     payload = request.json
 

--- a/backend/api/partner.py
+++ b/backend/api/partner.py
@@ -1,11 +1,13 @@
 """
 Partner Session API
 """
-from flask import jsonify, request
+from datetime import datetime, timedelta
+from flask import jsonify, request, Request
 
 from flask_common import app, db
 from models import HoagiePartner, PartnerSession
 
+AUTHORIZATION_PREFIX = 'Bearer '
 BASE_PARTNER_ORDER_ROUTE = '/api/partner/order'
 
 @app.route(f'/api/partner/<client_token>/session', methods=['POST'])
@@ -42,3 +44,29 @@ def create_partner_session_token(client_token: str):
         'refresh_token': None,
         'token_type': 'bearer'
     })
+
+
+##########
+# Helpers
+##########
+
+def authenticate_partner_request(request: Request):
+    if not request or not request.headers or not request.headers.get('Authorization'):
+        return False
+
+    authorization = request.headers['Authorization']
+
+    if not authorization or not authorization.startswith(AUTHORIZATION_PREFIX):
+        return False
+
+    access_token = authorization[len(AUTHORIZATION_PREFIX):]
+    partner_session: PartnerSession = PartnerSession.query.get(access_token)
+
+    if not partner_session:
+        return False
+
+    created_dttm = partner_session.created_dttm
+    duration = partner_session.duration
+    expiration = created_dttm + timedelta(seconds=duration)
+
+    return datetime.now() < expiration

--- a/backend/api/partner.py
+++ b/backend/api/partner.py
@@ -1,0 +1,44 @@
+"""
+Partner Session API
+"""
+from flask import jsonify, request
+
+from flask_common import app, db
+from models import HoagiePartner, PartnerSession
+
+BASE_PARTNER_ORDER_ROUTE = '/api/partner/order'
+
+@app.route(f'/api/partner/<client_token>/session', methods=['POST'])
+def create_partner_session_token(client_token: str):
+    """
+    Creates a session token for the partner with the given client_token.
+    payload:
+    {
+        client_secret: str
+    }
+    """
+
+    payload = request.json
+
+    if not payload or not payload['client_secret']:
+        return 'Invalid or missing credentials.', 404
+    
+    client_secret = payload.get('client_secret')
+
+    partner = HoagiePartner.query.filter(HoagiePartner.client_token == client_token, HoagiePartner.client_secret == client_secret).scalar()
+
+    if not partner:
+        return 'A partner with the given client_token does not exist.', 404
+    
+    partner_session = PartnerSession()
+    partner_session.hoagie_partner_id = partner.hoagie_partner_id
+
+    db.session.add(partner_session)
+    db.session.commit()
+    
+    return jsonify({
+        'access_token': partner_session.access_token,
+        'expires_in': partner_session.duration,
+        'refresh_token': None,
+        'token_type': 'bearer'
+    })

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -3,3 +3,4 @@ from .sandwich import Sandwich
 from .order import Order
 from .order_item import OrderItem
 from .product import Product
+from .partner_session import PartnerSession

--- a/backend/models/partner_session.py
+++ b/backend/models/partner_session.py
@@ -1,0 +1,37 @@
+"""
+Partner session model
+"""
+import random
+import string
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, ForeignKey, String, DateTime, DECIMAL, func
+
+from flask_common import db
+
+TOKEN_LENGTH = 32
+
+class PartnerSession(db.Model): # type: ignore
+    """
+    Represents a partner session
+    """
+
+    __tablename__= 'partner_session'
+
+    access_token: str = Column(String(TOKEN_LENGTH), primary_key=True)
+
+    hoagie_partner_id: int = Column(Integer, ForeignKey('hoagie_partner.hoagie_partner_id')) # type: ignore
+
+    created_dttm: datetime = Column(DateTime, # type: ignore
+                          server_default=func.current_timestamp()  # pylint: disable=no-member
+                          )
+    """ Time when session was created """
+
+    duration: int = Column(Integer, default=7200)
+    """ The duration of the session in seconds """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # Generate a random accesss_token
+        self.access_token = ''.join(random.choices(string.ascii_letters + string.digits, k=TOKEN_LENGTH))

--- a/backend/tests/api/order_test.py
+++ b/backend/tests/api/order_test.py
@@ -156,3 +156,13 @@ class OrderApiTest(HoagieTester):
             assert added_order.items[0].quantity == 2
             assert added_order.items[0].sandwich_id == 1
             assert added_order.status == Order.Status.SUBMITTED
+
+    def test_create_partner_order_without_items(self):
+        with app.test_client() as client:
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json')
+            assert result.status_code == 400
+
+    def test_create_partner_order_with_zero_items(self):
+        with app.test_client() as client:
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json')
+            assert result.status_code == 400

--- a/backend/tests/api/order_test.py
+++ b/backend/tests/api/order_test.py
@@ -2,7 +2,7 @@
 from curses import nonl
 from enum import Enum
 import json
-
+from flask.testing import FlaskClient
 from dacite import Config, from_dict
 
 
@@ -10,6 +10,7 @@ from api.order import BASE_ORDER_ROUTE, BASE_PARTNER_ORDER_ROUTE, ApiOrder, ApiO
 from app_main import db, app
 from models import Order
 from tests import HoagieTester
+from .partner_session_test import request_access_token
 
 
 class OrderApiTest(HoagieTester):
@@ -114,7 +115,7 @@ class OrderApiTest(HoagieTester):
             assert order.items[0].sandwich_id == item_input.sandwich_id
             assert order.items[0].quantity == item_input.quantity
 
-    def test_create_partner_order_without_phone_number(self):
+    def test_missing_partner_authorization(self):
         with app.test_client() as client:
             item_input = ApiOrderItemInput(
                 quantity=2,
@@ -123,6 +124,32 @@ class OrderApiTest(HoagieTester):
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
                 'items': [item_input.__dict__],
             }), content_type='application/json')
+
+            assert result.status_code == 401
+
+    def test_invalid_partner_authorization(self):
+        with app.test_client() as client:
+            item_input = ApiOrderItemInput(
+                quantity=2,
+                sandwich_id=1
+            )
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
+                'items': [item_input.__dict__],
+            }), content_type='application/json', headers={ 'Authorization': 'Bearer invalid_access_token'})
+
+            assert result.status_code == 401
+
+    def test_create_partner_order_without_phone_number(self):
+        with app.test_client() as client:
+            token_result = request_access_token(client)
+            access_token = token_result.json.get('access_token')
+            item_input = ApiOrderItemInput(
+                quantity=2,
+                sandwich_id=1
+            )
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
+                'items': [item_input.__dict__],
+            }), content_type='application/json', headers={ 'Authorization': f'Bearer {access_token}'})
             assert result.status_code == 200
             payload = result.json
             assert payload is not None
@@ -137,6 +164,8 @@ class OrderApiTest(HoagieTester):
 
     def test_create_partner_order_with_phone_number(self):
         with app.test_client() as client:
+            token_result = request_access_token(client)
+            access_token = token_result.json.get('access_token')
             item_input = ApiOrderItemInput(
                 quantity=2,
                 sandwich_id=1
@@ -144,7 +173,7 @@ class OrderApiTest(HoagieTester):
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
                 'items': [item_input.__dict__],
                 'phone_number': '+1 858 456 7890'
-            }), content_type='application/json')
+            }), content_type='application/json', headers={ 'Authorization': f'Bearer {access_token}'})
             assert result.status_code == 200
             payload = result.json
             assert payload is not None
@@ -159,21 +188,27 @@ class OrderApiTest(HoagieTester):
 
     def test_create_partner_order_without_items(self):
         with app.test_client() as client:
-            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json')
+            token_result = request_access_token(client)
+            access_token = token_result.json.get('access_token')
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json', headers={ 'Authorization': f'Bearer {access_token}'})
             assert result.status_code == 400
 
     def test_create_partner_order_with_empty_items(self):
         with app.test_client() as client:
-            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json')
+            token_result = request_access_token(client)
+            access_token = token_result.json.get('access_token')
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json', headers={ 'Authorization': f'Bearer {access_token}'})
             assert result.status_code == 400
 
     def test_create_partner_order_with_quantity_zero(self):
         with app.test_client() as client:
+            token_result = request_access_token(client)
+            access_token = token_result.json.get('access_token')
             item_input = ApiOrderItemInput(
                 quantity=0,
                 sandwich_id=1
             )
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
                 'items': [item_input.__dict__]
-            }), content_type='application/json')
+            }), content_type='application/json', headers={ 'Authorization': f'Bearer {access_token}'})
             assert result.status_code == 400

--- a/backend/tests/api/order_test.py
+++ b/backend/tests/api/order_test.py
@@ -162,7 +162,18 @@ class OrderApiTest(HoagieTester):
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({}), content_type='application/json')
             assert result.status_code == 400
 
-    def test_create_partner_order_with_zero_items(self):
+    def test_create_partner_order_with_empty_items(self):
         with app.test_client() as client:
             result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({ 'items': [] }), content_type='application/json')
+            assert result.status_code == 400
+
+    def test_create_partner_order_with_quantity_zero(self):
+        with app.test_client() as client:
+            item_input = ApiOrderItemInput(
+                quantity=0,
+                sandwich_id=1
+            )
+            result = client.post(f'{BASE_PARTNER_ORDER_ROUTE}/create', data=json.dumps({
+                'items': [item_input.__dict__]
+            }), content_type='application/json')
             assert result.status_code == 400

--- a/backend/tests/api/partner_session_test.py
+++ b/backend/tests/api/partner_session_test.py
@@ -1,0 +1,31 @@
+
+from enum import Enum
+import json
+
+from app_main import db, app
+from tests import HoagieTester
+
+
+class PartnerSessionAPITest(HoagieTester):
+    def test_create_session(self):
+        client_token = '-UalX1ujR6MIkczQGUMu9zuCyyNW0H-t'
+        client_secret = 'sxK3NaYyW34aW0V2JFRrr2crW5oAdASA'
+
+        with app.test_client() as client:
+            data = json.dumps({ 'client_secret': client_secret })
+            result = client.post(f'/api/partner/{ client_token }/session', data=data, content_type='application/json')
+            response = result.json
+
+            assert result.status_code == 200
+            assert response is not None
+            assert response.get('access_token') is not None
+
+    def test_invalid_credentials(self):
+        client_token = 'invalid_token'
+        client_secret = 'invalid_secret'
+
+        with app.test_client() as client:
+            data = json.dumps({ 'client_secret': client_secret })
+            result = client.post(f'/api/partner/{ client_token }/session', data=data, content_type='application/json')
+
+            assert result.status_code == 404

--- a/backend/tests/api/partner_session_test.py
+++ b/backend/tests/api/partner_session_test.py
@@ -1,19 +1,19 @@
 
 from enum import Enum
 import json
+from flask.testing import FlaskClient
 
-from app_main import db, app
+from app_main import app
 from tests import HoagieTester
 
+CLIENT_TOKEN = '-UalX1ujR6MIkczQGUMu9zuCyyNW0H-t'
+CLIENT_SECRET = 'sxK3NaYyW34aW0V2JFRrr2crW5oAdASA'
 
 class PartnerSessionAPITest(HoagieTester):
     def test_create_session(self):
-        client_token = '-UalX1ujR6MIkczQGUMu9zuCyyNW0H-t'
-        client_secret = 'sxK3NaYyW34aW0V2JFRrr2crW5oAdASA'
 
         with app.test_client() as client:
-            data = json.dumps({ 'client_secret': client_secret })
-            result = client.post(f'/api/partner/{ client_token }/session', data=data, content_type='application/json')
+            result = request_access_token(client, CLIENT_TOKEN, CLIENT_SECRET)
             response = result.json
 
             assert result.status_code == 200
@@ -21,11 +21,15 @@ class PartnerSessionAPITest(HoagieTester):
             assert response.get('access_token') is not None
 
     def test_invalid_credentials(self):
-        client_token = 'invalid_token'
-        client_secret = 'invalid_secret'
-
         with app.test_client() as client:
-            data = json.dumps({ 'client_secret': client_secret })
-            result = client.post(f'/api/partner/{ client_token }/session', data=data, content_type='application/json')
+            result = request_access_token(client, 'invalid_token', 'invalid_secret')
 
             assert result.status_code == 404
+
+##########
+# Helpers
+##########
+
+def request_access_token(client: FlaskClient, client_token: str = CLIENT_TOKEN, client_secret: str = CLIENT_SECRET):
+    data = json.dumps({ 'client_secret': client_secret })
+    return client.post(f'/api/partner/{ client_token }/session', data=data, content_type='application/json')


### PR DESCRIPTION
This PR adds a new API endpoint for partners to create access tokens.
The partner order creation API endpoint is also modified in this PR to authenticate partner requests.
Fixes #1.

Note: Please review and merge PR #5 **before** reviewing and merging this PR. In order to avoid merge conflicts, the branch `task-1029/partner-order-fix` was merged into this PR.

---

The authentication implemented in this pull request uses an HTTP `Authorization` header to authenticate the requests. This is a simple approach to authenticating requests and is adequate for the purposes of this assessment.

An alternative to this approach would be using Cookies. This approach works great for user facing applications, but might not be appropriate for partner facing API endpoints.

Another approach worth mentioning is adding a `signature` parameter to the requests. Similar to how most of the AWS APIs work (for instance, [this page](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html) explains how API requests to AWS S3 must be signed). Some of the benefits of this approach include:
* No need to generate an `access_token`.
* No need to send the `client_secret` to the API.
* The request has a built-in expiration mechanism.
* Helps prevent third parties from intercepting your requests and resubmitting them later.